### PR TITLE
Update ccplant chart with recommended production defaults

### DIFF
--- a/charts/ccplant/values.yaml
+++ b/charts/ccplant/values.yaml
@@ -3,7 +3,7 @@
 
 backend:
   # Backend (agentapi-proxy) specific configuration
-  replicaCount: 1
+  replicaCount: 2
   image:
     repository: ghcr.io/takutakahashi/agentapi-proxy
     tag: "latest"
@@ -14,29 +14,40 @@ backend:
     port: 8080
   
   ingress:
-    enabled: false
-    className: ""
-    annotations: {}
+    enabled: true
+    className: "nginx"
+    annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: /
+      nginx.ingress.kubernetes.io/ssl-redirect: "true"
     hosts:
-      - host: backend.ccplant.local
+      - host: api.ccplant.local
         paths:
-          - path: /
-            pathType: ImplementationSpecific
-    tls: []
+          - path: /api
+            pathType: Prefix
+    tls:
+      - secretName: ccplant-backend-tls
+        hosts:
+          - api.ccplant.local
   
-  resources: {}
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
   
   autoscaling:
-    enabled: false
-    minReplicas: 1
-    maxReplicas: 100
-    targetCPUUtilizationPercentage: 80
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
 
 frontend:
   # Frontend (agentapi-ui) specific configuration
-  replicaCount: 1
+  replicaCount: 2
   image:
-    repository: agentapi-ui
+    repository: ghcr.io/takutakahashi/agentapi-ui
     tag: "latest"
     pullPolicy: IfNotPresent
   
@@ -47,16 +58,27 @@ frontend:
   
   ingress:
     enabled: true
-    className: ""
-    annotations: {}
+    className: "nginx"
+    annotations:
+      nginx.ingress.kubernetes.io/ssl-redirect: "true"
+      nginx.ingress.kubernetes.io/proxy-body-size: "10m"
     hosts:
       - host: ccplant.local
         paths:
           - path: /
             pathType: Prefix
-    tls: []
+    tls:
+      - secretName: ccplant-frontend-tls
+        hosts:
+          - ccplant.local
   
-  resources: {}
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
   
   livenessProbe:
     httpGet:
@@ -73,17 +95,17 @@ frontend:
     periodSeconds: 5
   
   autoscaling:
-    enabled: false
-    minReplicas: 1
-    maxReplicas: 100
-    targetCPUUtilizationPercentage: 80
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 70
   
   # Environment variables for frontend
-  env: []
-  # - name: NODE_ENV
-  #   value: "production"
-  # - name: API_URL
-  #   value: "http://backend:8080"
+  env:
+    - name: NODE_ENV
+      value: "production"
+    - name: API_URL
+      value: "http://backend:8080"
 
 # Global configuration
 global:


### PR DESCRIPTION
## Summary
- Updated ccplant Helm chart with production-ready default values
- Enabled high availability and autoscaling configurations
- Added proper resource management and security settings

## Changes Made
- Set replicaCount to 2 for both backend and frontend services
- Enabled horizontal pod autoscaling with 70% CPU threshold
- Configured resource limits and requests for optimal resource utilization
- Enabled ingress with nginx class and SSL redirect annotations
- Added TLS configuration for secure communications
- Set production environment variables for frontend
- Updated frontend image repository to follow consistent naming pattern

## Test Plan
- [ ] Verify Helm chart validation passes
- [ ] Test deployment in staging environment
- [ ] Confirm autoscaling behavior under load
- [ ] Validate ingress and TLS configuration
- [ ] Check resource allocation and limits

🤖 Generated with [Claude Code](https://claude.ai/code)