### PR TITLE
OCI依存関係取得前にhelm registry loginを追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,10 @@ jobs:
         with:
           version: '3.18.3'
 
+      - name: Login to GitHub Container Registry for dependencies
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username ${{ github.actor }} --password-stdin
+
       - name: Update dependencies
         run: |
           cd charts/ccplant


### PR DESCRIPTION
## 概要
- `helm dependency update`でOCIレジストリからチャートを取得する前に、GitHub Container Registryへのログインを実行するように修正

## 問題
- Chart.yamlの依存関係でOCIレジストリ（`oci://ghcr.io/takutakahashi/charts`）を使用しているが、`helm dependency update`の前にレジストリログインが実行されていなかった
- これにより依存関係の取得が失敗する可能性があった

## 修正内容
- `helm dependency update`の前に`helm registry login`を実行するステップを追加
- GitHub Container Registryへのログイン処理を依存関係更新前に配置

## テスト計画
- [ ] ワークフローが正常に実行されることを確認
- [ ] 依存関係の更新が成功することを確認
- [ ] Helmチャートのパッケージングとプッシュが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)