### PR TITLE
Add docker-compose.yaml based on Helm configuration

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,77 @@
+version: '3.8'
+
+services:
+  # Backend service (agentapi-proxy)
+  backend:
+    image: ghcr.io/takutakahashi/agentapi-proxy:latest
+    container_name: ccplant-backend
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    networks:
+      - ccplant-network
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
+        reservations:
+          cpus: '0.1'
+          memory: 128M
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  # Frontend service (agentapi-ui)
+  frontend:
+    image: ghcr.io/takutakahashi/agentapi-ui:latest
+    container_name: ccplant-frontend
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=production
+      - API_URL=http://backend:8080
+    depends_on:
+      - backend
+    networks:
+      - ccplant-network
+    deploy:
+      resources:
+        limits:
+          cpus: '0.2'
+          memory: 256M
+        reservations:
+          cpus: '0.05'
+          memory: 64M
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  # Nginx reverse proxy (optional - for production-like setup)
+  nginx:
+    image: nginx:alpine
+    container_name: ccplant-nginx
+    restart: unless-stopped
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - backend
+      - frontend
+    networks:
+      - ccplant-network
+
+networks:
+  ccplant-network:
+    driver: bridge
+
+volumes:
+  # Add volumes here if needed for persistent data

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,36 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    upstream backend {
+        server backend:8080;
+    }
+    
+    upstream frontend {
+        server frontend:3000;
+    }
+    
+    server {
+        listen 80;
+        server_name localhost;
+        
+        # Frontend routes
+        location / {
+            proxy_pass http://frontend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+        
+        # Backend API routes
+        location /api {
+            proxy_pass http://backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Created docker-compose.yaml with backend (agentapi-proxy) and frontend (agentapi-ui) services
- Added nginx reverse proxy configuration for production-like setup
- Configured services based on existing Helm chart values and resource limits
- Added health checks and proper networking between services

## Test plan
- [ ] Verify docker-compose.yaml syntax is valid
- [ ] Test that services start up correctly with `docker-compose up`
- [ ] Verify backend is accessible on port 8080
- [ ] Verify frontend is accessible on port 3000
- [ ] Test nginx reverse proxy routes traffic correctly
- [ ] Confirm environment variables are properly set for frontend

🤖 Generated with [Claude Code](https://claude.ai/code)