### PR TITLE
Add Helm template test data for validation

### DIFF
--- a/.github/workflows/helm-template-validation.yml
+++ b/.github/workflows/helm-template-validation.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Generate Helm template output
       working-directory: charts/ccplant
       run: |
-        helm template ccplant . > /tmp/actual.yaml
+        helm template ccplant . --namespace default > /tmp/actual.yaml
 
     - name: Compare with expected output
       run: |

--- a/.github/workflows/helm-template-validation.yml
+++ b/.github/workflows/helm-template-validation.yml
@@ -1,0 +1,77 @@
+name: Helm Template Validation
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'charts/ccplant/**'
+      - 'testdata/expected.yaml'
+      - '.github/workflows/helm-template-validation.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - 'charts/ccplant/**'
+      - 'testdata/expected.yaml'
+      - '.github/workflows/helm-template-validation.yml'
+  workflow_dispatch:
+
+jobs:
+  validate-helm-template:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Setup Helm
+      uses: azure/setup-helm@v4
+      with:
+        version: 'v3.14.0'
+
+    - name: Login to GitHub Container Registry
+      run: |
+        echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username ${{ github.actor }} --password-stdin
+
+    - name: Update Helm dependencies
+      working-directory: charts/ccplant
+      run: |
+        helm dependency update
+
+    - name: Generate Helm template output
+      working-directory: charts/ccplant
+      run: |
+        helm template ccplant . > /tmp/actual.yaml
+
+    - name: Compare with expected output
+      run: |
+        if ! diff -u testdata/expected.yaml /tmp/actual.yaml; then
+          echo "::error::Helm template output differs from expected.yaml"
+          echo "::error::Please update testdata/expected.yaml by running:"
+          echo "::error::  cd charts/ccplant && helm template ccplant . > ../../testdata/expected.yaml"
+          exit 1
+        fi
+        echo "✅ Helm template output matches expected.yaml"
+
+    - name: Upload actual output as artifact
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: helm-template-actual
+        path: /tmp/actual.yaml
+        retention-days: 7
+
+    - name: Upload diff as artifact
+      if: failure()
+      run: |
+        diff -u testdata/expected.yaml /tmp/actual.yaml > /tmp/diff.txt || true
+
+    - name: Upload diff artifact
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: helm-template-diff
+        path: /tmp/diff.txt
+        retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+charts/ccplant/charts/

--- a/charts/ccplant/Chart.lock
+++ b/charts/ccplant/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: agentapi-proxy
+  repository: file://../../../agentapi-proxy/helm/agentapi-proxy
+  version: 0.3.0
+- name: agentapi-ui
+  repository: file://../../../agentapi-ui/helm/agentapi-ui
+  version: v0.1.0
+digest: sha256:b500c106b7b98f630df0971ae1cb14726a4308f612a3cbab83a1b00559876d73
+generated: "2026-01-21T11:22:55.565735983Z"

--- a/charts/ccplant/Chart.lock
+++ b/charts/ccplant/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: agentapi-proxy
-  repository: file://../../../agentapi-proxy/helm/agentapi-proxy
-  version: 0.3.0
+  repository: oci://ghcr.io/takutakahashi/charts
+  version: v1.187.0
 - name: agentapi-ui
-  repository: file://../../../agentapi-ui/helm/agentapi-ui
-  version: v0.1.0
-digest: sha256:b500c106b7b98f630df0971ae1cb14726a4308f612a3cbab83a1b00559876d73
-generated: "2026-01-21T11:22:55.565735983Z"
+  repository: oci://ghcr.io/takutakahashi/charts
+  version: v1.94.0
+digest: sha256:2f8a5f95ec236bac93fbec0e3d7707c2b3c624f6aacf75c7b0c27dd0d21ec88d
+generated: "2026-01-21T12:06:12.454322104Z"

--- a/charts/ccplant/Chart.yaml
+++ b/charts/ccplant/Chart.yaml
@@ -7,8 +7,8 @@ appVersion: "1.0.0"
 
 dependencies:
   - name: agentapi-proxy
-    version: "v1.41.2"
-    repository: "oci://ghcr.io/takutakahashi/charts"
+    version: "0.3.0"
+    repository: "file://../../../agentapi-proxy/helm/agentapi-proxy"
   - name: agentapi-ui
-    version: "1.8.0"
-    repository: "oci://ghcr.io/takutakahashi/charts"
+    version: "v0.1.0"
+    repository: "file://../../../agentapi-ui/helm/agentapi-ui"

--- a/charts/ccplant/Chart.yaml
+++ b/charts/ccplant/Chart.yaml
@@ -7,8 +7,8 @@ appVersion: "1.0.0"
 
 dependencies:
   - name: agentapi-proxy
-    version: "0.3.0"
-    repository: "file://../../../agentapi-proxy/helm/agentapi-proxy"
+    version: "v1.187.0"
+    repository: "oci://ghcr.io/takutakahashi/charts"
   - name: agentapi-ui
-    version: "v0.1.0"
-    repository: "file://../../../agentapi-ui/helm/agentapi-ui"
+    version: "v1.94.0"
+    repository: "oci://ghcr.io/takutakahashi/charts"

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+helm = "latest"

--- a/scripts/update-expected-helm-template.sh
+++ b/scripts/update-expected-helm-template.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+
+# Script to update the expected Helm template output for testing
+# Usage: ./scripts/update-expected-helm-template.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CHART_DIR="${REPO_ROOT}/charts/ccplant"
+EXPECTED_FILE="${REPO_ROOT}/testdata/expected.yaml"
+
+echo "📦 Updating Helm dependencies..."
+cd "${CHART_DIR}"
+helm dependency update
+
+echo "🔨 Generating Helm template output..."
+helm template ccplant . > "${EXPECTED_FILE}"
+
+echo "✅ Successfully updated ${EXPECTED_FILE}"
+echo ""
+echo "Generated output:"
+wc -l "${EXPECTED_FILE}"
+echo ""
+echo "To commit this change:"
+echo "  git add testdata/expected.yaml"
+echo "  git commit -m 'Update expected Helm template output'"

--- a/scripts/update-expected-helm-template.sh
+++ b/scripts/update-expected-helm-template.sh
@@ -14,7 +14,7 @@ cd "${CHART_DIR}"
 helm dependency update
 
 echo "🔨 Generating Helm template output..."
-helm template ccplant . > "${EXPECTED_FILE}"
+helm template ccplant . --namespace default > "${EXPECTED_FILE}"
 
 echo "✅ Successfully updated ${EXPECTED_FILE}"
 echo ""

--- a/testdata/expected.yaml
+++ b/testdata/expected.yaml
@@ -140,7 +140,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: ccplant-agentapi-proxy
-    namespace: agentapi-ui
+    namespace: default
 roleRef:
   kind: Role
   name: ccplant-agentapi-proxy-session-manager
@@ -160,7 +160,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: agentapi-proxy-session
-    namespace: agentapi-ui
+    namespace: default
 roleRef:
   kind: Role
   name: agentapi-proxy-session
@@ -307,7 +307,7 @@ spec:
             - name: AGENTAPI_K8S_SESSION_ENABLED
               value: "true"
             - name: AGENTAPI_K8S_SESSION_NAMESPACE
-              value: "agentapi-ui"
+              value: "default"
             - name: AGENTAPI_K8S_SESSION_IMAGE
               value: "ghcr.io/takutakahashi/agentapi-proxy:v1.187.0"
             - name: AGENTAPI_K8S_SESSION_IMAGE_PULL_POLICY

--- a/testdata/expected.yaml
+++ b/testdata/expected.yaml
@@ -5,10 +5,10 @@ kind: ServiceAccount
 metadata:
   name: ccplant-agentapi-proxy
   labels:
-    helm.sh/chart: agentapi-proxy-0.3.0
+    helm.sh/chart: agentapi-proxy-v1.187.0
     app.kubernetes.io/name: agentapi-proxy
     app.kubernetes.io/instance: ccplant
-    app.kubernetes.io/version: "1.173.0"
+    app.kubernetes.io/version: "v1.187.0"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 ---
@@ -18,10 +18,10 @@ kind: ServiceAccount
 metadata:
   name: agentapi-proxy-session
   labels:
-    helm.sh/chart: agentapi-proxy-0.3.0
+    helm.sh/chart: agentapi-proxy-v1.187.0
     app.kubernetes.io/name: agentapi-proxy
     app.kubernetes.io/instance: ccplant
-    app.kubernetes.io/version: "1.173.0"
+    app.kubernetes.io/version: "v1.187.0"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 ---
@@ -31,10 +31,10 @@ kind: ServiceAccount
 metadata:
   name: ccplant-agentapi-ui
   labels:
-    helm.sh/chart: agentapi-ui-v0.1.0
+    helm.sh/chart: agentapi-ui-v1.94.0
     app.kubernetes.io/name: agentapi-ui
     app.kubernetes.io/instance: ccplant
-    app.kubernetes.io/version: "v0.1.0"
+    app.kubernetes.io/version: "v1.94.0"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 ---
@@ -44,10 +44,10 @@ kind: ConfigMap
 metadata:
   name: ccplant-agentapi-proxy-auth-config
   labels:
-    helm.sh/chart: agentapi-proxy-0.3.0
+    helm.sh/chart: agentapi-proxy-v1.187.0
     app.kubernetes.io/name: agentapi-proxy
     app.kubernetes.io/instance: ccplant
-    app.kubernetes.io/version: "1.173.0"
+    app.kubernetes.io/version: "v1.187.0"
     app.kubernetes.io/managed-by: Helm
 data:
   auth-config.yaml: |
@@ -66,10 +66,10 @@ kind: Role
 metadata:
   name: ccplant-agentapi-proxy-session-manager
   labels:
-    helm.sh/chart: agentapi-proxy-0.3.0
+    helm.sh/chart: agentapi-proxy-v1.187.0
     app.kubernetes.io/name: agentapi-proxy
     app.kubernetes.io/instance: ccplant
-    app.kubernetes.io/version: "1.173.0"
+    app.kubernetes.io/version: "v1.187.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: [""]
@@ -104,10 +104,10 @@ kind: Role
 metadata:
   name: agentapi-proxy-session
   labels:
-    helm.sh/chart: agentapi-proxy-0.3.0
+    helm.sh/chart: agentapi-proxy-v1.187.0
     app.kubernetes.io/name: agentapi-proxy
     app.kubernetes.io/instance: ccplant
-    app.kubernetes.io/version: "1.173.0"
+    app.kubernetes.io/version: "v1.187.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   # Minimal permissions for session pods
@@ -132,10 +132,10 @@ kind: RoleBinding
 metadata:
   name: ccplant-agentapi-proxy-session-manager
   labels:
-    helm.sh/chart: agentapi-proxy-0.3.0
+    helm.sh/chart: agentapi-proxy-v1.187.0
     app.kubernetes.io/name: agentapi-proxy
     app.kubernetes.io/instance: ccplant
-    app.kubernetes.io/version: "1.173.0"
+    app.kubernetes.io/version: "v1.187.0"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount
@@ -152,10 +152,10 @@ kind: RoleBinding
 metadata:
   name: agentapi-proxy-session
   labels:
-    helm.sh/chart: agentapi-proxy-0.3.0
+    helm.sh/chart: agentapi-proxy-v1.187.0
     app.kubernetes.io/name: agentapi-proxy
     app.kubernetes.io/instance: ccplant
-    app.kubernetes.io/version: "1.173.0"
+    app.kubernetes.io/version: "v1.187.0"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount
@@ -172,10 +172,10 @@ kind: Service
 metadata:
   name: ccplant-agentapi-proxy
   labels:
-    helm.sh/chart: agentapi-proxy-0.3.0
+    helm.sh/chart: agentapi-proxy-v1.187.0
     app.kubernetes.io/name: agentapi-proxy
     app.kubernetes.io/instance: ccplant
-    app.kubernetes.io/version: "1.173.0"
+    app.kubernetes.io/version: "v1.187.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -198,10 +198,10 @@ kind: Service
 metadata:
   name: ccplant-agentapi-ui
   labels:
-    helm.sh/chart: agentapi-ui-v0.1.0
+    helm.sh/chart: agentapi-ui-v1.94.0
     app.kubernetes.io/name: agentapi-ui
     app.kubernetes.io/instance: ccplant
-    app.kubernetes.io/version: "v0.1.0"
+    app.kubernetes.io/version: "v1.94.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -220,10 +220,10 @@ kind: Deployment
 metadata:
   name: ccplant-agentapi-proxy
   labels:
-    helm.sh/chart: agentapi-proxy-0.3.0
+    helm.sh/chart: agentapi-proxy-v1.187.0
     app.kubernetes.io/name: agentapi-proxy
     app.kubernetes.io/instance: ccplant
-    app.kubernetes.io/version: "1.173.0"
+    app.kubernetes.io/version: "v1.187.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 3
@@ -234,10 +234,10 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: agentapi-proxy-0.3.0
+        helm.sh/chart: agentapi-proxy-v1.187.0
         app.kubernetes.io/name: agentapi-proxy
         app.kubernetes.io/instance: ccplant
-        app.kubernetes.io/version: "1.173.0"
+        app.kubernetes.io/version: "v1.187.0"
         app.kubernetes.io/managed-by: Helm
     spec:
       serviceAccountName: ccplant-agentapi-proxy
@@ -249,7 +249,7 @@ spec:
         - name: agentapi-proxy
           securityContext:
             null
-          image: "ghcr.io/takutakahashi/agentapi-proxy:1.173.0"
+          image: "ghcr.io/takutakahashi/agentapi-proxy:v1.187.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -309,7 +309,7 @@ spec:
             - name: AGENTAPI_K8S_SESSION_NAMESPACE
               value: "agentapi-ui"
             - name: AGENTAPI_K8S_SESSION_IMAGE
-              value: "ghcr.io/takutakahashi/agentapi-proxy:1.173.0"
+              value: "ghcr.io/takutakahashi/agentapi-proxy:v1.187.0"
             - name: AGENTAPI_K8S_SESSION_IMAGE_PULL_POLICY
               value: "IfNotPresent"
             - name: AGENTAPI_K8S_SESSION_SERVICE_ACCOUNT
@@ -413,10 +413,10 @@ kind: Deployment
 metadata:
   name: ccplant-agentapi-ui
   labels:
-    helm.sh/chart: agentapi-ui-v0.1.0
+    helm.sh/chart: agentapi-ui-v1.94.0
     app.kubernetes.io/name: agentapi-ui
     app.kubernetes.io/instance: ccplant
-    app.kubernetes.io/version: "v0.1.0"
+    app.kubernetes.io/version: "v1.94.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -427,10 +427,10 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: agentapi-ui-v0.1.0
+        helm.sh/chart: agentapi-ui-v1.94.0
         app.kubernetes.io/name: agentapi-ui
         app.kubernetes.io/instance: ccplant
-        app.kubernetes.io/version: "v0.1.0"
+        app.kubernetes.io/version: "v1.94.0"
         app.kubernetes.io/managed-by: Helm
     spec:
       serviceAccountName: ccplant-agentapi-ui
@@ -440,7 +440,7 @@ spec:
         - name: agentapi-ui
           securityContext:
             {}
-          image: "ghcr.io/takutakahashi/agentapi-ui:v0.1.0"
+          image: "ghcr.io/takutakahashi/agentapi-ui:v1.94.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -508,10 +508,10 @@ kind: Ingress
 metadata:
   name: ccplant-agentapi-proxy
   labels:
-    helm.sh/chart: agentapi-proxy-0.3.0
+    helm.sh/chart: agentapi-proxy-v1.187.0
     app.kubernetes.io/name: agentapi-proxy
     app.kubernetes.io/instance: ccplant
-    app.kubernetes.io/version: "1.173.0"
+    app.kubernetes.io/version: "v1.187.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
@@ -543,10 +543,10 @@ kind: Ingress
 metadata:
   name: ccplant-agentapi-ui
   labels:
-    helm.sh/chart: agentapi-ui-v0.1.0
+    helm.sh/chart: agentapi-ui-v1.94.0
     app.kubernetes.io/name: agentapi-ui
     app.kubernetes.io/instance: ccplant
-    app.kubernetes.io/version: "v0.1.0"
+    app.kubernetes.io/version: "v1.94.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   ingressClassName: nginx

--- a/testdata/expected.yaml
+++ b/testdata/expected.yaml
@@ -1,0 +1,567 @@
+---
+# Source: ccplant/charts/agentapi-proxy/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ccplant-agentapi-proxy
+  labels:
+    helm.sh/chart: agentapi-proxy-0.3.0
+    app.kubernetes.io/name: agentapi-proxy
+    app.kubernetes.io/instance: ccplant
+    app.kubernetes.io/version: "1.173.0"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: ccplant/charts/agentapi-proxy/templates/session-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agentapi-proxy-session
+  labels:
+    helm.sh/chart: agentapi-proxy-0.3.0
+    app.kubernetes.io/name: agentapi-proxy
+    app.kubernetes.io/instance: ccplant
+    app.kubernetes.io/version: "1.173.0"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: ccplant/charts/agentapi-ui/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ccplant-agentapi-ui
+  labels:
+    helm.sh/chart: agentapi-ui-v0.1.0
+    app.kubernetes.io/name: agentapi-ui
+    app.kubernetes.io/instance: ccplant
+    app.kubernetes.io/version: "v0.1.0"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: ccplant/charts/agentapi-proxy/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ccplant-agentapi-proxy-auth-config
+  labels:
+    helm.sh/chart: agentapi-proxy-0.3.0
+    app.kubernetes.io/name: agentapi-proxy
+    app.kubernetes.io/instance: ccplant
+    app.kubernetes.io/version: "1.173.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  auth-config.yaml: |
+    github:
+      user_mapping:
+        default_role: "user"
+        default_permissions:
+          - "session:create"
+          - "session:list"
+          - "session:delete"
+          - "session:access"
+---
+# Source: ccplant/charts/agentapi-proxy/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ccplant-agentapi-proxy-session-manager
+  labels:
+    helm.sh/chart: agentapi-proxy-0.3.0
+    app.kubernetes.io/name: agentapi-proxy
+    app.kubernetes.io/instance: ccplant
+    app.kubernetes.io/version: "1.173.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "create", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "create", "update", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+  # Leader election for schedule worker (enabled by default)
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+# Source: ccplant/charts/agentapi-proxy/templates/session-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: agentapi-proxy-session
+  labels:
+    helm.sh/chart: agentapi-proxy-0.3.0
+    app.kubernetes.io/name: agentapi-proxy
+    app.kubernetes.io/instance: ccplant
+    app.kubernetes.io/version: "1.173.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  # Minimal permissions for session pods
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list"]
+  # Permissions for credentials-sync sidecar to sync credentials.json to Secret
+  # Note: 'get' is not needed - uses create-first then replace approach
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "update"]
+---
+# Source: ccplant/charts/agentapi-proxy/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ccplant-agentapi-proxy-session-manager
+  labels:
+    helm.sh/chart: agentapi-proxy-0.3.0
+    app.kubernetes.io/name: agentapi-proxy
+    app.kubernetes.io/instance: ccplant
+    app.kubernetes.io/version: "1.173.0"
+    app.kubernetes.io/managed-by: Helm
+subjects:
+  - kind: ServiceAccount
+    name: ccplant-agentapi-proxy
+    namespace: agentapi-ui
+roleRef:
+  kind: Role
+  name: ccplant-agentapi-proxy-session-manager
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: ccplant/charts/agentapi-proxy/templates/session-rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agentapi-proxy-session
+  labels:
+    helm.sh/chart: agentapi-proxy-0.3.0
+    app.kubernetes.io/name: agentapi-proxy
+    app.kubernetes.io/instance: ccplant
+    app.kubernetes.io/version: "1.173.0"
+    app.kubernetes.io/managed-by: Helm
+subjects:
+  - kind: ServiceAccount
+    name: agentapi-proxy-session
+    namespace: agentapi-ui
+roleRef:
+  kind: Role
+  name: agentapi-proxy-session
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: ccplant/charts/agentapi-proxy/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: ccplant-agentapi-proxy
+  labels:
+    helm.sh/chart: agentapi-proxy-0.3.0
+    app.kubernetes.io/name: agentapi-proxy
+    app.kubernetes.io/instance: ccplant
+    app.kubernetes.io/version: "1.173.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: 9000
+      targetPort: 9000
+      protocol: TCP
+      name: agentapi-base
+  selector:
+    app.kubernetes.io/name: agentapi-proxy
+    app.kubernetes.io/instance: ccplant
+---
+# Source: ccplant/charts/agentapi-ui/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: ccplant-agentapi-ui
+  labels:
+    helm.sh/chart: agentapi-ui-v0.1.0
+    app.kubernetes.io/name: agentapi-ui
+    app.kubernetes.io/instance: ccplant
+    app.kubernetes.io/version: "v0.1.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3000
+      targetPort: 3000
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: agentapi-ui
+    app.kubernetes.io/instance: ccplant
+---
+# Source: ccplant/charts/agentapi-proxy/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ccplant-agentapi-proxy
+  labels:
+    helm.sh/chart: agentapi-proxy-0.3.0
+    app.kubernetes.io/name: agentapi-proxy
+    app.kubernetes.io/instance: ccplant
+    app.kubernetes.io/version: "1.173.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: agentapi-proxy
+      app.kubernetes.io/instance: ccplant
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: agentapi-proxy-0.3.0
+        app.kubernetes.io/name: agentapi-proxy
+        app.kubernetes.io/instance: ccplant
+        app.kubernetes.io/version: "1.173.0"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      serviceAccountName: ccplant-agentapi-proxy
+      securityContext:
+        fsGroup: 999
+        runAsUser: 999
+        runAsGroup: 999
+      containers:
+        - name: agentapi-proxy
+          securityContext:
+            null
+          image: "ghcr.io/takutakahashi/agentapi-proxy:1.173.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: agentapi-start
+              containerPort: 9000
+              protocol: TCP
+          env:
+            - name: HOME
+              value: "/home/agentapi"
+            # Application configuration via environment variables (AGENTAPI_ prefix)
+            - name: AGENTAPI_AUTH_ENABLED
+              value: "true"
+            - name: AGENTAPI_AUTH_STATIC_ENABLED
+              value: "false"
+            - name: AGENTAPI_AUTH_STATIC_HEADER_NAME
+              value: "X-API-Key"
+            - name: AGENTAPI_AUTH_GITHUB_ENABLED
+              value: "true"
+            - name: AGENTAPI_AUTH_GITHUB_BASE_URL
+              value: "https://api.github.com"
+            - name: AGENTAPI_AUTH_GITHUB_TOKEN_HEADER
+              value: "Authorization"
+            - name: AGENTAPI_AUTH_GITHUB_OAUTH_CLIENT_ID
+              value: ""
+            - name: AGENTAPI_AUTH_GITHUB_OAUTH_CLIENT_SECRET
+              value: ""
+            - name: AGENTAPI_AUTH_GITHUB_OAUTH_SCOPE
+              value: "read:user read:org repo workflow"
+            - name: AGENTAPI_AUTH_GITHUB_OAUTH_BASE_URL
+              value: ""
+            - name: AGENTAPI_AUTH_CONFIG_FILE
+              value: "/etc/auth-config/auth-config.yaml"
+            # Role-based environment files configuration
+            - name: AGENTAPI_ROLE_ENV_FILES_ENABLED
+              value: "false"
+            - name: AGENTAPI_ROLE_ENV_FILES_PATH
+              value: "/etc/role-env-files"
+            - name: AGENTAPI_ROLE_ENV_FILES_LOAD_DEFAULT
+              value: "true"
+            - name: GITHUB_APP_PEM
+              valueFrom:
+                secretKeyRef:
+                  name: github-app
+                  key: private-key
+            - name: GITHUB_APP_PEM_PATH
+              value: "/etc/github-app/private-key"
+            - name: NOTIFICATION_BASE_URL
+              value: "https://cc-dev.example.com"
+            # Webhook configuration
+            - name: AGENTAPI_WEBHOOK_BASE_URL
+              value: "https://cc-dev.example.com"
+            # Kubernetes Session Management configuration
+            - name: AGENTAPI_K8S_SESSION_ENABLED
+              value: "true"
+            - name: AGENTAPI_K8S_SESSION_NAMESPACE
+              value: "agentapi-ui"
+            - name: AGENTAPI_K8S_SESSION_IMAGE
+              value: "ghcr.io/takutakahashi/agentapi-proxy:1.173.0"
+            - name: AGENTAPI_K8S_SESSION_IMAGE_PULL_POLICY
+              value: "IfNotPresent"
+            - name: AGENTAPI_K8S_SESSION_SERVICE_ACCOUNT
+              value: "agentapi-proxy-session"
+            - name: AGENTAPI_K8S_SESSION_BASE_PORT
+              value: "9000"
+            - name: AGENTAPI_K8S_SESSION_CPU_REQUEST
+              value: "500m"
+            - name: AGENTAPI_K8S_SESSION_CPU_LIMIT
+              value: "2"
+            - name: AGENTAPI_K8S_SESSION_MEMORY_REQUEST
+              value: "512Mi"
+            - name: AGENTAPI_K8S_SESSION_MEMORY_LIMIT
+              value: "4Gi"
+            - name: AGENTAPI_K8S_SESSION_PVC_ENABLED
+              value: "false"
+            - name: AGENTAPI_K8S_SESSION_PVC_STORAGE_CLASS
+              value: ""
+            - name: AGENTAPI_K8S_SESSION_PVC_STORAGE_SIZE
+              value: "10Gi"
+            - name: AGENTAPI_K8S_SESSION_POD_START_TIMEOUT
+              value: "120"
+            - name: AGENTAPI_K8S_SESSION_POD_STOP_TIMEOUT
+              value: "30"
+            # OpenTelemetry Collector configuration
+            - name: AGENTAPI_KUBERNETES_SESSION_OTEL_COLLECTOR_ENABLED
+              value: "true"
+            - name: AGENTAPI_KUBERNETES_SESSION_OTEL_COLLECTOR_IMAGE
+              value: "otel/opentelemetry-collector-contrib:0.143.1"
+            - name: AGENTAPI_KUBERNETES_SESSION_OTEL_COLLECTOR_SCRAPE_INTERVAL
+              value: "15s"
+            - name: AGENTAPI_KUBERNETES_SESSION_OTEL_COLLECTOR_CLAUDE_CODE_PORT
+              value: "9464"
+            - name: AGENTAPI_KUBERNETES_SESSION_OTEL_COLLECTOR_EXPORTER_PORT
+              value: "9090"
+            - name: AGENTAPI_KUBERNETES_SESSION_OTEL_COLLECTOR_CPU_REQUEST
+              value: "100m"
+            - name: AGENTAPI_KUBERNETES_SESSION_OTEL_COLLECTOR_CPU_LIMIT
+              value: "200m"
+            - name: AGENTAPI_KUBERNETES_SESSION_OTEL_COLLECTOR_MEMORY_REQUEST
+              value: "128Mi"
+            - name: AGENTAPI_KUBERNETES_SESSION_OTEL_COLLECTOR_MEMORY_LIMIT
+              value: "256Mi"
+            # MCP server configuration
+            - name: AGENTAPI_K8S_SESSION_MCP_SERVERS_ENABLED
+              value: "true"
+            - name: AGENTAPI_K8S_SESSION_MCP_SERVERS_BASE_SECRET
+              value: "mcp-servers-base"
+            # Schedule Worker configuration (enabled by default)
+            - name: AGENTAPI_SCHEDULE_WORKER_ENABLED
+              value: "true"
+            - name: AGENTAPI_SCHEDULE_WORKER_CHECK_INTERVAL
+              value: "30s"
+            # GitHub Token configuration (for backward compatibility)
+            # Claude Code configuration
+            # OAuth configuration
+            # VAPID configuration
+          volumeMounts:
+            - name: auth-config
+              mountPath: /etc/auth-config
+              readOnly: true
+            - name: github-app-private-key
+              mountPath: /etc/github-app
+              readOnly: true
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+          resources:
+            limits:
+              cpu: 8
+              memory: 8Gi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+      volumes:
+        - name: auth-config
+          configMap:
+            name: ccplant-agentapi-proxy-auth-config
+        - name: github-app-private-key
+          secret:
+            secretName: github-app
+            defaultMode: 0440
+---
+# Source: ccplant/charts/agentapi-ui/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ccplant-agentapi-ui
+  labels:
+    helm.sh/chart: agentapi-ui-v0.1.0
+    app.kubernetes.io/name: agentapi-ui
+    app.kubernetes.io/instance: ccplant
+    app.kubernetes.io/version: "v0.1.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: agentapi-ui
+      app.kubernetes.io/instance: ccplant
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: agentapi-ui-v0.1.0
+        app.kubernetes.io/name: agentapi-ui
+        app.kubernetes.io/instance: ccplant
+        app.kubernetes.io/version: "v0.1.0"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      serviceAccountName: ccplant-agentapi-ui
+      securityContext:
+        {}
+      containers:
+        - name: agentapi-ui
+          securityContext:
+            {}
+          image: "ghcr.io/takutakahashi/agentapi-ui:v0.1.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          env:
+            - name: ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: agentapi-ui-encryption
+                  key: encryption-key
+            - name: COOKIE_ENCRYPTION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: agentapi-ui-encryption
+                  key: cookie-encryption-secret
+            - name: COOKIE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: agentapi-ui-encryption
+                  key: cookie-encryption-secret
+            - name: AGENTAPI_PROXY_URL
+              value: "http://ccplant-backend:8080"
+            - name: NEXT_PUBLIC_ALLOWED_ORIGINS
+              value: "https://cc-dev.example.com"
+            # Application configuration (runtime settings)
+            - name: AUTH_MODE
+              value: "oauth_only"
+            - name: LOGIN_TITLE
+              value: "agentapi-ui"
+            - name: LOGIN_DESCRIPTION
+              value: "welcome"
+            - name: LOGIN_SUB_DESCRIPTION
+              value: "agentapi-ui"
+            # PWA configuration
+            - name: PWA_APP_NAME
+              value: "AgentAPI UI"
+            - name: PWA_SHORT_NAME
+              value: "AgentAPI"
+            - name: PWA_DESCRIPTION
+              value: "User interface for AgentAPI - AI agent conversation management"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+---
+# Source: ccplant/charts/agentapi-proxy/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ccplant-agentapi-proxy
+  labels:
+    helm.sh/chart: agentapi-proxy-0.3.0
+    app.kubernetes.io/name: agentapi-proxy
+    app.kubernetes.io/instance: ccplant
+    app.kubernetes.io/version: "1.173.0"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/proxy-body-size: 100m
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - "agentapi.example.com"
+      secretName: agentapi-proxy-tls
+  rules:
+    - host: "agentapi.example.com"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ccplant-agentapi-proxy
+                port:
+                  number: 8080
+---
+# Source: ccplant/charts/agentapi-ui/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ccplant-agentapi-ui
+  labels:
+    helm.sh/chart: agentapi-ui-v0.1.0
+    app.kubernetes.io/name: agentapi-ui
+    app.kubernetes.io/instance: ccplant
+    app.kubernetes.io/version: "v0.1.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - "cc-dev.example.com"
+      secretName: ccplant-agentapi-ui-tls
+  rules:
+    - host: cc-dev.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ccplant-agentapi-ui
+                port:
+                  number: 3000


### PR DESCRIPTION
## Summary

テストワークフローでhelm templateの結果を検証済みのマニフェストと比較できるように、testdataディレクトリに期待される出力を追加しました。

### 変更内容

- **testdata/expected.yaml**: `helm template ccplant . --namespace default` の出力結果(567行)
- **Chart.yaml**: OCI registryを使用するように更新
  - `agentapi-proxy`: v1.187.0 (グローバル値対応版)
  - `agentapi-ui`: v1.94.0 (グローバル値対応版)
  - repository: `oci://ghcr.io/takutakahashi/charts`
- **Chart.lock**: 依存関係のバージョンを記録
- **.gitignore**: `charts/ccplant/charts/` を追加
- **.github/workflows/helm-template-validation.yml**: Helm template検証のCIワークフロー
- **scripts/update-expected-helm-template.sh**: expected.yamlを更新するためのヘルパースクリプト
- **mise.toml**: Helmツール依存関係の定義

### テストの目的

このexpected.yamlファイルを使用して:
1. CIワークフローで `helm template` を実行
2. 出力をexpected.yamlと比較
3. 意図しない変更がないことを確認

### CIワークフロー

`.github/workflows/helm-template-validation.yml` が以下の処理を実行します:
- PR/mainへのpush時に、chart関連ファイルの変更を検知して自動実行
- OCI registryから最新の依存チャートをダウンロード
- Helm templateを `--namespace default` オプション付きで生成
- `testdata/expected.yaml` との差分をチェック
- 差分がある場合はエラーとし、実際の出力と差分をartifactとしてアップロード

### ヘルパースクリプト

`scripts/update-expected-helm-template.sh` を実行することで、expected.yamlを簡単に更新できます:

```bash
./scripts/update-expected-helm-template.sh
```

### 重要な変更

#### OCI Registry の使用
ローカルの file:// 依存関係ではなく、OCI registry (ghcr.io) から公開されている最新版のチャートを使用しています。これにより、実際のデプロイ環境と同じチャートバージョンでテストできます。

#### Namespace の明示的指定
helm template コマンドに `--namespace default` を明示的に指定することで、ローカル環境の HELM_NAMESPACE 環境変数の影響を受けずに一貫した結果を得られます。

### 使用方法

```bash
# 依存関係を更新
cd charts/ccplant && helm dependency update

# テンプレートを生成
helm template ccplant . --namespace default > /tmp/actual.yaml

# 差分を確認
diff testdata/expected.yaml /tmp/actual.yaml
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)