### PR TITLE
Update Helm chart dependencies to latest versions

### DIFF
--- a/charts/ccplant/Chart.yaml
+++ b/charts/ccplant/Chart.yaml
@@ -7,8 +7,8 @@ appVersion: "1.0.0"
 
 dependencies:
   - name: agentapi-proxy
-    version: "v1.187.0"
+    version: "v1.191.0"
     repository: "oci://ghcr.io/takutakahashi/charts"
   - name: agentapi-ui
-    version: "v1.94.0"
+    version: "v1.97.0"
     repository: "oci://ghcr.io/takutakahashi/charts"


### PR DESCRIPTION
## Summary
- Update agentapi-proxy dependency from v1.187.0 to v1.191.0
- Update agentapi-ui dependency from v1.97.0 to v1.97.0

This PR updates the Helm chart dependencies to use the latest versions from the respective repositories.

## Changes
- `charts/ccplant/Chart.yaml`: Updated dependency versions for agentapi-proxy and agentapi-ui

## Test plan
- [ ] Verify Chart.yaml syntax is correct
- [ ] Test Helm chart installation with updated dependencies
- [ ] Confirm both services start correctly with new versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)